### PR TITLE
Add cell-level permissions

### DIFF
--- a/markdown/plugins/cell-permissions.md
+++ b/markdown/plugins/cell-permissions.md
@@ -1,0 +1,20 @@
+# Cell Permission Matrix
+
+This feature allows defining permissions per cell using a matrix of **role**, **row** and **column**. Rules are stored in the `nc_permissions` table.
+
+## Example Matrix
+
+| Role  | Row ID | Column ID | Permission |
+|-------|-------|-----------|------------|
+| owner | r1    | c1        | EDIT       |
+| viewer| r1    | c1        | VIEW       |
+
+The matrix above grants owners edit access while viewers can only view that cell.
+
+Use the following endpoints to manage permissions:
+
+- `POST /api/v1/db/meta/cell-permissions` – create or update a rule
+- `GET /api/v1/db/meta/cell-permissions?rowId=...&columnId=...&role=...` – check access
+- `DELETE /api/v1/db/meta/cell-permissions/:id` – remove a rule
+
+The `AclMiddleware` checks these rules for `dataRead` and `dataUpdate` requests.

--- a/packages/nocodb/src/controllers/cell-permission-matrix.controller.ts
+++ b/packages/nocodb/src/controllers/cell-permission-matrix.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { PermissionKey, PermissionRole } from 'nocodb-sdk';
+import { Acl } from '~/middlewares/extract-ids/extract-ids.middleware';
+import { GlobalGuard } from '~/guards/global/global.guard';
+import { TenantContext } from '~/decorators/tenant-context.decorator';
+import type { NcContext } from '~/interface/config';
+import { CellPermissionMatrixService } from '~/services/cell-permission-matrix.service';
+
+@Controller()
+@UseGuards(GlobalGuard)
+export class CellPermissionMatrixController {
+  constructor(private readonly service: CellPermissionMatrixService) {}
+
+  @Post('/api/v1/db/meta/cell-permissions')
+  @Acl('cellPermissionSet')
+  async setPermission(
+    @TenantContext() context: NcContext,
+    @Body()
+    body: { rowId: string; columnId: string; role: PermissionRole; permission: PermissionKey | string },
+  ) {
+    return this.service.setPermission(context, body);
+  }
+
+  @Get('/api/v1/db/meta/cell-permissions')
+  @Acl('cellPermissionGet')
+  async getPermission(
+    @TenantContext() context: NcContext,
+    @Query('rowId') rowId: string,
+    @Query('columnId') columnId: string,
+    @Query('role') role: PermissionRole,
+  ) {
+    return this.service.getCellAccess(context, { rowId, columnId, role });
+  }
+
+  @Delete('/api/v1/db/meta/cell-permissions/:id')
+  @Acl('cellPermissionDelete')
+  async deletePermission(@TenantContext() context: NcContext, @Param('id') id: string) {
+    return this.service.deletePermission(context, id);
+  }
+}

--- a/packages/nocodb/src/meta/migrations/v2/nc_083_permissions.ts
+++ b/packages/nocodb/src/meta/migrations/v2/nc_083_permissions.ts
@@ -11,6 +11,10 @@ const up = async (knex: Knex) => {
     table.string('entity', 255); // table, column etc.
     table.string('entity_id', 255); // table id, column id etc.
 
+    // matrix specific ids for row and column
+    table.string('row_id', 20);
+    table.string('column_id', 20);
+
     table.string('permission', 255); // TABLE_RECORD_ADD, TABLE_RECORD_DELETE, FIELD_EDIT etc.
 
     table.string('created_by', 20); // user id
@@ -27,6 +31,7 @@ const up = async (knex: Knex) => {
 
     table.index(['base_id', 'fk_workspace_id'], 'nc_permissions_context');
     table.index(['entity', 'entity_id', 'permission'], 'nc_permissions_entity');
+    table.index(['row_id', 'column_id', 'permission'], 'nc_permissions_cell');
   });
 
   await knex.schema.createTable(MetaTable.PERMISSION_SUBJECTS, (table) => {

--- a/packages/nocodb/src/middlewares/extract-ids/extract-ids.middleware.ts
+++ b/packages/nocodb/src/middlewares/extract-ids/extract-ids.middleware.ts
@@ -7,6 +7,7 @@ import {
   ProjectRoles,
   SourceRestriction,
 } from 'nocodb-sdk';
+import { CellPermissionMatrixService } from '~/services/cell-permission-matrix.service';
 import { map } from 'rxjs';
 import type { Observable } from 'rxjs';
 import type {
@@ -421,7 +422,10 @@ function getUserRoleForScope(user: any, scope: string) {
 
 @Injectable()
 export class AclMiddleware implements NestInterceptor {
-  constructor(private reflector: Reflector) {}
+  constructor(
+    private reflector: Reflector,
+    private readonly cellPermissionMatrixService: CellPermissionMatrixService,
+  ) {}
 
   async aclFn(
     permissionName: string,
@@ -518,14 +522,29 @@ export class AclMiddleware implements NestInterceptor {
           })));
     if (!isAllowed) {
       NcError.permissionDenied(permissionName, roles, extendedScopeRoles);
+    }
 
-      // NcError.forbidden(
-      //
-      //
-      //   `${permissionName} - ${getRolesLabels(
-      //     Object.keys(roles).filter((k) => roles[k]),
-      //   )} : Not allowed`,
-      // );
+    if (
+      (permissionName === 'dataRead' || permissionName === 'dataUpdate') &&
+      req.params?.rowId &&
+      req.params?.columnId
+    ) {
+      const access = await this.cellPermissionMatrixService.getCellAccess(
+        req.context,
+        {
+          rowId: req.params.rowId,
+          columnId: req.params.columnId,
+          role: userScopeRole as any,
+        },
+      );
+
+      if (permissionName === 'dataRead' && access === 'none') {
+        NcError.permissionDenied(permissionName, roles, extendedScopeRoles);
+      }
+
+      if (permissionName === 'dataUpdate' && access !== 'edit') {
+        NcError.permissionDenied(permissionName, roles, extendedScopeRoles);
+      }
     }
 
     // check if permission have source level permission restriction

--- a/packages/nocodb/src/modules/noco.module.ts
+++ b/packages/nocodb/src/modules/noco.module.ts
@@ -151,6 +151,8 @@ import { TablesV3Service } from '~/services/v3/tables-v3.service';
 import { ViewsV3Service } from '~/services/v3/views-v3.service';
 import { ViewRowColorController } from '~/controllers/view-row-color.controller';
 import { AttachmentUrlUploadHandler } from '~/services/emit-handler/attachment-url-upload.handler';
+import { CellPermissionMatrixController } from '~/controllers/cell-permission-matrix.controller';
+import { CellPermissionMatrixService } from '~/services/cell-permission-matrix.service';
 
 /* ACL */
 import { AclMiddleware } from '~/middlewares/extract-ids/extract-ids.middleware';
@@ -221,6 +223,7 @@ export const nocoModuleMetadata = {
           ExtensionsController,
           JobsMetaController,
           IntegrationsController,
+          CellPermissionMatrixController,
           InternalController,
 
           // MCP
@@ -317,6 +320,7 @@ export const nocoModuleMetadata = {
     McpTokenService,
     McpService,
     ViewRowColorService,
+    CellPermissionMatrixService,
 
     /* Datas */
     DataTableService,
@@ -374,6 +378,7 @@ export const nocoModuleMetadata = {
     IntegrationsService,
     NocoJobsService,
     ViewRowColorService,
+    CellPermissionMatrixService,
 
     /* Datas */
     DatasService,

--- a/packages/nocodb/src/services/cell-permission-matrix.service.ts
+++ b/packages/nocodb/src/services/cell-permission-matrix.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { PermissionKey, PermissionRole } from 'nocodb-sdk';
+import type { NcContext } from '~/interface/config';
+import { MetaService } from '~/meta/meta.service';
+import { MetaTable } from '~/utils/globals';
+
+export type CellAccessFlag = 'view' | 'edit' | 'none';
+
+@Injectable()
+export class CellPermissionMatrixService {
+  constructor(private readonly metaService: MetaService) {}
+
+  async setPermission(
+    context: NcContext,
+    params: {
+      rowId: string;
+      columnId: string;
+      role: PermissionRole;
+      permission: PermissionKey | string;
+    },
+  ) {
+    await this.metaService.metaDelete(
+      context.workspace_id,
+      context.base_id,
+      MetaTable.PERMISSIONS,
+      {
+        row_id: params.rowId,
+        column_id: params.columnId,
+        granted_role: params.role,
+        permission: params.permission,
+      },
+    );
+
+    return this.metaService.metaInsert2(
+      context.workspace_id,
+      context.base_id,
+      MetaTable.PERMISSIONS,
+      {
+        fk_workspace_id: context.workspace_id,
+        base_id: context.base_id,
+        entity: 'cell',
+        entity_id: `${params.rowId}:${params.columnId}`,
+        row_id: params.rowId,
+        column_id: params.columnId,
+        permission: params.permission,
+        granted_type: 'role',
+        granted_role: params.role,
+      },
+    );
+  }
+
+  async deletePermission(context: NcContext, id: string) {
+    return this.metaService.metaDelete(
+      context.workspace_id,
+      context.base_id,
+      MetaTable.PERMISSIONS,
+      id,
+    );
+  }
+
+  async getCellAccess(
+    context: NcContext,
+    params: { rowId: string; columnId: string; role: PermissionRole },
+  ): Promise<CellAccessFlag> {
+    const perms = await this.metaService.metaList2(
+      context.workspace_id,
+      context.base_id,
+      MetaTable.PERMISSIONS,
+      {
+        condition: {
+          row_id: params.rowId,
+          column_id: params.columnId,
+          granted_role: params.role,
+        },
+      },
+    );
+
+    const hasEdit = perms.some(
+      (p) => p.permission === PermissionKey.RECORD_FIELD_EDIT || p.permission === 'EDIT',
+    );
+    if (hasEdit) return 'edit';
+
+    const hasView = perms.some((p) => p.permission === 'VIEW');
+    if (hasView) return 'view';
+
+    return 'none';
+  }
+}

--- a/packages/nocodb/src/utils/acl.ts
+++ b/packages/nocodb/src/utils/acl.ts
@@ -180,6 +180,9 @@ const permissionScopes = {
     'mcpCreate',
     'mcpUpdate',
     'mcpDelete',
+    'cellPermissionSet',
+    'cellPermissionGet',
+    'cellPermissionDelete',
   ],
 };
 
@@ -318,6 +321,11 @@ const rolePermissions:
     },
   },
   [ProjectRoles.OWNER]: {
+    include: {
+      cellPermissionSet: true,
+      cellPermissionGet: true,
+      cellPermissionDelete: true,
+    },
     exclude: {
       pluginList: true,
       pluginTest: true,
@@ -691,6 +699,9 @@ const permissionDescriptions: Record<string, string> = {
   mcpCreate: 'create a new MCP token',
   mcpUpdate: 'update an MCP token',
   mcpDelete: 'delete an MCP token',
+  cellPermissionSet: 'update cell permissions',
+  cellPermissionGet: 'view cell permissions',
+  cellPermissionDelete: 'delete cell permissions',
 };
 
 // Human-readable descriptions for roles


### PR DESCRIPTION
## Summary
- migrate permissions table with row and column info
- check matrix with CellPermissionMatrixService
- validate rights via middleware
- expose CRUD API for cell permission matrix
- document row/column permission matrix

## Testing
- `pnpm --filter=nocodb test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887a5d50fd88332862a54bbd79cff5d